### PR TITLE
chore: add more configuration options

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -19,15 +19,22 @@ default_config: &default_config # run the check every 1 second
 databases:
   db-dev-primary:
     <<: *default_config
-    address: dev-db-primary:3306
+    address: dev-db-primary
+    port: 3306
     schema: web-us1
+    ssl_cert: /etc/mysql/certs/dev-db-primary-cert.crt
+    ssl_key: /etc/mysql/certs/dev-db-primary-key.key
+    ssl_ca: /etc/mysql/certs/dev-db-primary-ca.crt
+
   db-dev-replica0:
     <<: *default_config
-    address: dev-db-replica0:3306
+    address: dev-db-replica0
+    port: 3306
     schema: web-us1
   db-dev-replica1:
     <<: *default_config
-    address: dev-db-replica1:3306
+    address: dev-db-replica1
+    port: 3306
     schema: web-us1
     interval: 10s
     long_query_limit: 60s

--- a/configs/kubernetes_config.yaml
+++ b/configs/kubernetes_config.yaml
@@ -17,15 +17,18 @@ default_config: &default_config # run the check every 1 second
 # are stored in the file defined above, and the keys to each database entry must match.
 databases:
   dev-primary:
-    address: mysql-us1-primary.mysql.svc.cluster.local:3306
+    address: mysql-us1-primary.mysql.svc.cluster.local
+    port: 3306
     schema: web-us1
     <<: *default_config
   dev-replica0:
-    address: mysql-us1-replica0.mysql.svc.cluster.local:3306
+    address: mysql-us1-replica0.mysql.svc.cluster.local
+    port: 3306
     schema: web-us1
     <<: *default_config
   dev-replica1:
-    address: mysql-us1-replica1.mysql.svc.cluster.local:3306
+    address: mysql-us1-replica1.mysql.svc.cluster.local
+    port: 3306
     schema: web-us1
     interval: 10s
     long_query_limit: 60s

--- a/internal/configuration/testdata/test_config.yaml
+++ b/internal/configuration/testdata/test_config.yaml
@@ -8,19 +8,22 @@ log:
 
 databases:
   test_primary:
-    address: 127.0.0.1:3306
+    address: 127.0.0.1
+    port: 3306
     schema: test_schema
     long_query_limit: 60s
     interval: 10s
   # replica has the same settings as primary, as it's used in loadbalancing.
   test_replica:
-    address: 127.0.0.1:3307
+    address: 127.0.0.1
+    port: 3307
     schema: test_schema
     long_query_limit: 60s
     interval: 10s
   # the analytics database is used for longer running queries, so make the limits more lenient.
   test_analytics:
-    address: 127.0.0.1:3308
+    address: 127.0.0.1
+    port: 3308
     schema: test_schema
     long_query_limit: 120s
     long_transaction_limit: 240s


### PR DESCRIPTION
- change the address config ion the database config block from `address:port` to address only
- add a port config option to the database config block, including validation
- add ssl config options to the database config block, including validation for the various combinations