### PR TITLE
chore: don't log the queries that snipers use in INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **Clean up logging**: Don't log the long query and long transaction queries that snipers use to `INFO`. Only `DEBUG` or `TRACE` will show the queries now
+
 ## 0.1.3 - 2025-09-12
 
 - **SSL Certificate Validation**: Add comprehensive SSL configuration validation to prevent insecure certificate combinations

--- a/internal/sniper/sniper.go
+++ b/internal/sniper/sniper.go
@@ -179,8 +179,15 @@ func New(name string, settings *configuration.Config) (QuerySniper, error) {
 		slog.Duration("transaction_limit", sniper.TransactionLimit),
 		slog.Bool("dry_run", sniper.DryRun),
 		slog.Bool("safe_mode_active", settings.SafeMode),
-		slog.String("lrq_query", sniper.LRQQuery),
-		slog.String("lrtxn_query", sniper.LRTXNQuery),
+	)
+
+	// if we're in debug mode, log the queries that will be run by the snipers. this should clean up the logs in normal mode.
+	slog.Debug("Sniper queries",
+		slog.String("name", sniper.Name),
+		slog.Group("queries",
+			slog.String("long_query", sniper.LRQQuery),
+			slog.String("long_transaction", sniper.LRTXNQuery),
+		),
 	)
 
 	return sniper, nil


### PR DESCRIPTION
- moved the queries that snipers use to the DEBUG log level, so that the initial startup logs are cleaner.

**Potential Risk**

Worst Case Incident: SEV(1|2|3|4)

**Testing Strategy**

Stuff here