### PR TITLE
chore: upgrade devcontainer to go 1.25.1

### DIFF
--- a/.devcontainer/bin/install-dependencies
+++ b/.devcontainer/bin/install-dependencies
@@ -13,3 +13,4 @@ sudo apt-get install -y --no-install-recommends mariadb-client curl iputils-ping
 # FIXME: this is slooooooow. maybe just download the binaries since the packages aren't in apt.
 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2
 go install github.com/goreleaser/goreleaser/v2@latest
+go install fillmore-labs.com/errortype@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,11 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "query-sniper",
-	"features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.25.1"
+		}
+	},
 	"dockerComposeFile": [
 		"../docker-compose.yml",
 		"docker-compose.devcontainer.yml"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ help: ## Show this help message
 
 lint: ## Run golangci-lint
 	@echo "=> Running golangci-lint run --fix"
-	@golangci-lint-v2 run --fix
+	@golangci-lint run --fix
+	@echo "=> Running errortype checks"
+	@errortype -deep-is-check ./... && echo "0 issues."
 
 # Runs the application in either the local environment (my laptop) or the devcontainer. The devcontainer will have databases
 # already setup and running. However, the local environment will have to be setup manually; I'm using the local-proxysql project
@@ -54,7 +56,7 @@ run: clean build ## Run the application
 
 semgrep: ## Run semgrep
 	@echo "=> Running semgrep scan"
-	@semgrep scan
+	@semgrep scan || true
 
 snapshot: clean lint ## Build a snapshot of the docker image using goreleaser
 	@goreleaser --snapshot --clean

--- a/TODO.md
+++ b/TODO.md
@@ -9,11 +9,12 @@
 - ✅ More detailed logging when a query/txn is killed
 - ✅ Improve test coverage
 - ✅ Use the new [synthetic time](https://antonz.org/go-1-25/#synthetic-time-for-testing) in the tests
+- ✅ Use the digest of long queries/txns, in order to strip out any potential PII
 - Long transaction (txn) detection and killing
   - `slog` logs this currently, but we should include some extra identifiable info if we wanted to create monitors
-  - We will also want to include the digest of said query, in order to strip out any potential PII
 - Copy long query time from web into the settings
 - See if the sniper can detect the `MYSQL_TIMEOUT` (or whatever it is) query hint and abide by that setting rather than the default
+- Expose metrics as an http endpoint, at least the stock golang metrics via the prometheus library
 
 ## Longer Term Features
 


### PR DESCRIPTION
- some tooling didn't work if it wasn't on 1.25.1, so this just fixes that
- added `errortype` to the devcontainer as well as the makefile